### PR TITLE
Add result page for error cases

### DIFF
--- a/static/css/result.css
+++ b/static/css/result.css
@@ -19,6 +19,10 @@ body {
   .disliked-bg {
     background-image: url('https://images.unsplash.com/photo-1495561604046-3108243c72e4?q=80&w=2001&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'); 
   }
+
+  .unknown-bg {
+    background-image: url('https://images.unsplash.com/photo-1513082325166-c105b20374bb?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'); 
+  }
   
   .result-box {
     background-color: #ffffffee;
@@ -57,6 +61,15 @@ body {
   .disliked {
     background-color: #f8d7da;
     color: #721c24;
+  }
+
+  .unknown {
+    background-color: #dcd7f8;
+    color: #373644;
+  }
+
+  .error-text {
+    font-size: 1rem;
   }
   
   .emoji {

--- a/templates/result.html
+++ b/templates/result.html
@@ -5,7 +5,7 @@
   <title>Sentiment Result</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/result.css') }}">
 </head>
-<body class="{% if sentiment == '1' %}liked-bg{% else %}disliked-bg{% endif %}">
+<body class="{% if sentiment == '1' %}liked-bg{% elif sentiment == '0' %}disliked-bg{% else %}unknown-bg{% endif %}">
   <div class="result-box">
     <h1>Sentiment Analysis Result</h1>
     <p class="review-text">"{{ review }}"</p>
@@ -13,12 +13,19 @@
     {% if sentiment == '1' %}
       <div class="sentiment-box liked">
         <div class="emoji">👍</div>
-        The customer liked this review!
+        The customer liked this restaurant!
       </div>
-    {% else %}
+    {% elif sentiment == '0' %}
       <div class="sentiment-box disliked">
         <div class="emoji">👎</div>
         The customer did not like this restaurant.
+      </div>
+    {% else %}
+      <div class="sentiment-box unknown">
+        <div class="emoji">❓</div>
+        Customer sentiment unknown:
+        
+        <p class="error-text">{{ sentiment }}</p>
       </div>
     {% endif %}
 


### PR DESCRIPTION
The original implementation defaults to the results page for negative reviews, even when the model is unreachable. That makes evaluating the model's predictions a bit more tedious (because you must ALWAYS test the connection to model-service first with a guaranteed positive review).

This change adds an "unknown' results page with a different background image, text, and emoji. It also prints the error for fasting debugging.

I have tested that it does not break the original implementation, but feel free to check before merging.