### PR TITLE
Defining Prometheus monitoring metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/remla25-team12/lib-version.git@v0.1.3#egg=lib-version-remla25-team12
 flask==3.1.0
 requests==2.32.3
+prometheus_client


### PR DESCRIPTION
- 2 counter metrics, 1 gauge metric, and 3 histogram metrics are defined. In total, 6 monitoring metrics are defined and exposed to Prometheus via a new endpoint.
- TODO: The logic for active users gauge metric should be updated!